### PR TITLE
feat: Add German language support

### DIFF
--- a/gameCategories.json
+++ b/gameCategories.json
@@ -4,12 +4,14 @@
       "id": "animals",
       "name": {
         "en-US": "Animals",
-        "sq-AL": "Kafshët"
+        "sq-AL": "Kafshët",
+        "de-DE": "Tiere"
       },
       "imagePath": "images/animals/animals.jpg",
       "description": {
         "en-US": "Learn about different animals",
-        "sq-AL": "Mësoni për kafshët e ndryshme"
+        "sq-AL": "Mësoni për kafshët e ndryshme",
+        "de-DE": "Lerne verschiedene Tiere kennen"
       },
       "soundEffect": "sounds/general/animals-intro.mp3"
     },
@@ -17,12 +19,14 @@
       "id": "numbers",
       "name": {
         "en-US": "Numbers",
-        "sq-AL": "Numrat"
+        "sq-AL": "Numrat",
+        "de-DE": "Zahlen"
       },
       "imagePath": "images/numbers/numbers.jpg",
       "description": {
         "en-US": "Learn to count numbers",
-        "sq-AL": "Mësoni të numërosh numrat"
+        "sq-AL": "Mësoni të numërosh numrat",
+        "de-DE": "Lerne Zahlen zu zählen"
       },
       "soundEffect": "sounds/general/numbers-intro.mp3"
     },
@@ -30,12 +34,14 @@
       "id": "cartoons",
       "name": {
         "en-US": "Cartoons",
-        "sq-AL": "Filma të vizatuar"
+        "sq-AL": "Filma të vizatuar",
+        "de-DE": "Zeichentrickfilme"
       },
       "imagePath": "images/cartoons/cartoons.jpg",
       "description": {
         "en-US": "Fun cartoon characters",
-        "sq-AL": "Personazhe të këndshëm të filmave vizatimorë"
+        "sq-AL": "Personazhe të këndshëm të filmave vizatimorë",
+        "de-DE": "Lustige Zeichentrickfiguren"
       },
       "soundEffect": "sounds/general/cartoons-intro.mp3"
     }

--- a/gameData.json
+++ b/gameData.json
@@ -7,7 +7,8 @@
       "soundPath": "sounds/animals/dog-barking.wav",
       "alternativePronunciations": {
         "en-US": ["dog", "doggy", "doggie"],
-        "sq-AL": ["qen", "qeni"]
+        "sq-AL": ["qen", "qeni"],
+        "de-DE": ["hund", "hundchen"]
       },
       "level": "easy",
       "points": 3
@@ -19,7 +20,8 @@
       "soundPath": "sounds/animals/cat-meowing.wav",
       "alternativePronunciations": {
         "en-US": ["cat", "kitty", "kitten"],
-        "sq-AL": ["mace", "maca", "macja", "kotele"]
+        "sq-AL": ["mace", "maca", "macja", "kotele"],
+        "de-DE": ["katze", "katzen"]
       },
       "level": "easy",
       "points": 3
@@ -31,7 +33,8 @@
       "soundPath": "sounds/animals/bird-singing.mp3",
       "alternativePronunciations": {
         "en-US": ["bird", "birdie", "birdy"],
-        "sq-AL": ["zog", "zogë", "zogu"]
+        "sq-AL": ["zog", "zogë", "zogu"],
+        "de-DE": ["vogel", "vogelchen"]
       },
       "level": "medium",
       "points": 5
@@ -43,7 +46,8 @@
       "soundPath": null,
       "alternativePronunciations": {
         "en-US": ["fish", "fishy", "fishi"],
-        "sq-AL": ["peshk", "peshkë", "peshku"]
+        "sq-AL": ["peshk", "peshkë", "peshku"],
+        "de-DE": ["fisch", "fische"]
       },
       "level": "medium",
       "points": 5
@@ -55,7 +59,8 @@
       "soundPath": "sounds/animals/snake-hissing.mp3",
       "alternativePronunciations": {
         "en-US": ["snake", "snakey"],
-        "sq-AL": ["gjarper", "gjarpri", "gjarpër", "gjarpëri"]
+        "sq-AL": ["gjarper", "gjarpri", "gjarpër", "gjarpëri"],
+        "de-DE": ["schlange", "schlangen"]
       },
       "level": "hard",
       "points": 10
@@ -67,7 +72,8 @@
       "soundPath": "sounds/animals/tiger-roar.wav",
       "alternativePronunciations": {
         "en-US": ["tiger", "tiggy"],
-        "sq-AL": ["tigër", "tigëri", "tigri"]
+        "sq-AL": ["tigër", "tigëri", "tigri"],
+        "de-DE": ["tiger", "tigerchen"]
       },
       "level": "hard",
       "points": 10
@@ -79,7 +85,8 @@
       "soundPath": "sounds/animals/elephant-trumpeting.mp3",
       "alternativePronunciations": {
         "en-US": ["elephant", "elephanty"],
-        "sq-AL": ["elefant", "elefantë", "elefanti"]
+        "sq-AL": ["elefant", "elefantë", "elefanti"],
+        "de-DE": ["elefant", "elefanten"]
       },
       "level": "hard",
       "points": 10
@@ -98,7 +105,8 @@
           "lion cat",
           "lion king"
         ],
-        "sq-AL": ["luan", "luani", "mbreti i xhunglës"]
+        "sq-AL": ["luan", "luani", "mbreti i xhunglës"],
+        "de-DE": ["löwe", "löwen"]
       },
       "level": "hard",
       "points": 10
@@ -110,7 +118,8 @@
       "soundPath": "sounds/animals/bear-growling.mp3",
       "alternativePronunciations": {
         "en-US": ["bear", "beary"],
-        "sq-AL": ["ari", "ariu", "arusha"]
+        "sq-AL": ["ari", "ariu", "arusha"],
+        "de-DE": ["bär", "bären"]
       },
       "level": "medium",
       "points": 5
@@ -122,7 +131,8 @@
       "soundPath": "sounds/animals/horse-whinnying.mp3",
       "alternativePronunciations": {
         "en-US": ["horse", "horsey"],
-        "sq-AL": ["kali"]
+        "sq-AL": ["kali"],
+        "de-DE": ["pferd", "pferde"]
       },
       "level": "medium",
       "points": 5
@@ -134,7 +144,8 @@
       "soundPath": null,
       "alternativePronunciations": {
         "en-US": ["one", "number one", "1", "number 1"],
-        "sq-AL": ["një", "numri një", "numëri një", "1", "numri 1", "numëri 1"]
+        "sq-AL": ["një", "numri një", "numëri një", "1", "numri 1", "numëri 1"],
+        "de-DE": ["eins", "ein", "1", "eine"]
       },
       "level": "easy",
       "points": 3
@@ -146,7 +157,8 @@
       "soundPath": null,
       "alternativePronunciations": {
         "en-US": ["two", "number two", "2", "number 2"],
-        "sq-AL": ["dy", "numri dy", "numëri dy", "2", "numri 2", "numëri 2"]
+        "sq-AL": ["dy", "numri dy", "numëri dy", "2", "numri 2", "numëri 2"],
+        "de-DE": ["zwei", "zweie", "2", "zwei"]
       },
       "level": "hard",
       "points": 10
@@ -158,7 +170,8 @@
       "soundPath": null,
       "alternativePronunciations": {
         "en-US": ["three", "number three", "3", "number 3"],
-        "sq-AL": ["tre", "numri tre", "numëri tre", "3", "numri 3", "numëri 3"]
+        "sq-AL": ["tre", "numri tre", "numëri tre", "3", "numri 3", "numëri 3"],
+        "de-DE": ["drei", "dreie", "3", "drei"]
       },
       "level": "easy",
       "points": 3
@@ -177,7 +190,8 @@
           "4",
           "numri 4",
           "numëri 4"
-        ]
+        ],
+        "de-DE": ["vier", "viere", "4", "vier"]
       },
       "level": "hard",
       "points": 10
@@ -196,7 +210,8 @@
           "5",
           "numri 5",
           "numëri 5"
-        ]
+        ],
+        "de-DE": ["fünf", "fünfte", "5", "fünf"]
       },
       "level": "easy",
       "points": 3
@@ -215,7 +230,8 @@
           "6",
           "numri 6",
           "numëri 6"
-        ]
+        ],
+        "de-DE": ["sechs", "sechste", "6", "sechs"]
       },
       "level": "medium",
       "points": 5
@@ -234,7 +250,8 @@
           "7",
           "numri 7",
           "numëri 7"
-        ]
+        ],
+        "de-DE": ["sieben", "siebte", "7", "sieben"]
       },
       "level": "medium",
       "points": 5
@@ -253,7 +270,8 @@
           "8",
           "numri 8",
           "numëri 8"
-        ]
+        ],
+        "de-DE": ["acht", "achte", "8", "acht"]
       },
       "level": "medium",
       "points": 5
@@ -272,7 +290,8 @@
           "9",
           "numri 9",
           "numëri 9"
-        ]
+        ],
+        "de-DE": ["neun", "neunze", "9", "neun"]
       },
       "level": "easy",
       "points": 3
@@ -291,7 +310,8 @@
           "10",
           "numri 10",
           "numëri 10"
-        ]
+        ],
+        "de-DE": ["zehn", "zehnte", "10", "zehn"]
       },
       "level": "easy",
       "points": 3
@@ -310,7 +330,8 @@
           "11",
           "numri 11",
           "numëri 11"
-        ]
+        ],
+        "de-DE": ["elf", "elfte", "11", "elf"]
       },
       "level": "hard",
       "points": 10
@@ -328,7 +349,8 @@
           "spongjbob",
           "spongj bob",
           "Bob Sfungjeri"
-        ]
+        ],
+        "de-DE": ["elf", "elfte", "11", "elf"]
       },
       "level": "medium",
       "points": 5
@@ -347,7 +369,8 @@
           "spajdermeni",
           "spajdërmeni",
           "njeriu merimangë"
-        ]
+        ],
+        "de-DE": ["spider-man", "spiderman"]
       },
       "level": "medium",
       "points": 5
@@ -359,7 +382,8 @@
       "soundPath": "sounds/cartoons/batman-theme.mp3",
       "alternativePronunciations": {
         "en-US": ["batman"],
-        "sq-AL": ["batman", "betmen", "betmeni"]
+        "sq-AL": ["batman", "betmen", "betmeni"],
+        "de-DE": ["batman"]
       },
       "level": "medium",
       "points": 5
@@ -371,7 +395,8 @@
       "soundPath": "sounds/cartoons/superman-theme.mp3",
       "alternativePronunciations": {
         "en-US": ["superman"],
-        "sq-AL": ["superman", "supermen", "supermeni", "super njeriu"]
+        "sq-AL": ["superman", "supermen", "supermeni", "super njeriu"],
+        "de-DE": ["superman"]
       },
       "level": "medium",
       "points": 5
@@ -388,7 +413,8 @@
           "lightning mcqueen",
           "vetura rrufe",
           "makina rrufe"
-        ]
+        ],
+        "de-DE": ["mcqueen", "lightning mcqueen"]
       },
       "level": "hard",
       "points": 10
@@ -406,7 +432,8 @@
           "miki maus",
           "miki mausi",
           "Miushi Miki"
-        ]
+        ],
+        "de-DE": ["mickey mouse", "mickey"]
       },
       "level": "hard",
       "points": 10
@@ -418,7 +445,8 @@
       "soundPath": "sounds/cartoons/hello-banana.mp3",
       "alternativePronunciations": {
         "en-US": ["minions", "miniony"],
-        "sq-AL": ["minions", "minionat"]
+        "sq-AL": ["minions", "minionat"],
+        "de-DE": ["minions", "minionen"]
       },
       "level": "medium",
       "points": 5
@@ -438,7 +466,8 @@
           "tomi gjeri",
           "tom dhe gjeri",
           "tomi dhe gjeri"
-        ]
+        ],
+        "de-DE": ["tom and jerry", "tommy jerry", "tommy and jerry"]
       },
       "level": "hard",
       "points": 10
@@ -450,7 +479,8 @@
       "soundPath": "sounds/cartoons/shrek-song.mp3",
       "alternativePronunciations": {
         "en-US": ["shrek"],
-        "sq-AL": ["shrek", "shreku", "përbindshi i gjelbërt"]
+        "sq-AL": ["shrek", "shreku", "përbindshi i gjelbërt"],
+        "de-DE": ["shrek"]
       },
       "level": "hard",
       "points": 10
@@ -462,7 +492,13 @@
       "soundPath": "sounds/cartoons/pink-panther-theme.mp3",
       "alternativePronunciations": {
         "en-US": ["pink panther"],
-        "sq-AL": ["pink panther", "pink panter", "pink panteri", "Pantera rozë"]
+        "sq-AL": [
+          "pink panther",
+          "pink panter",
+          "pink panteri",
+          "Pantera rozë"
+        ],
+        "de-DE": ["pink panther"]
       },
       "level": "medium",
       "points": 5

--- a/gameScript.js
+++ b/gameScript.js
@@ -53,9 +53,15 @@ window.setLanguage = (lang) => {
     if (lang === 'en-US') {
         flag.src = 'images/flags/us.svg';
         currentLanguage.textContent = 'English';
-    } else {
+    } else if (lang === 'de-DE') {
+        flag.src = 'images/flags/de.svg';
+        currentLanguage.textContent = 'Deutsch';
+    } else if (lang === 'sq-AL') {
         flag.src = 'images/flags/al.svg';
         currentLanguage.textContent = 'Shqip';
+    } else {
+        flag.src = 'images/flags/us.svg';
+        currentLanguage.textContent = 'English';
     }
 
     // Hide dropdown

--- a/images/flags/de.svg
+++ b/images/flags/de.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-de" viewBox="0 0 640 480">
+  <path fill="#fc0" d="M0 320h640v160H0z"/>
+  <path fill="#000001" d="M0 0h640v160H0z"/>
+  <path fill="red" d="M0 160h640v160H0z"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -63,6 +63,13 @@
             <img src="images/flags/al.svg" alt="AL" class="w-10 h-10" />
             <span>Shqip</span>
           </div>
+          <div
+            class="flex items-center gap-2 px-4 py-2 hover:bg-gray-100 cursor-pointer"
+            onclick="setLanguage('de-DE')"
+          >
+            <img src="images/flags/de.svg" alt="DE" class="w-10 h-10" />
+            <span>Deutsch</span>
+          </div>
         </div>
       </div>
     </div>

--- a/langPhrases.json
+++ b/langPhrases.json
@@ -34,5 +34,22 @@
     "playSound": "Luaj audion",
     "pauseSound": "Ndalo audion",
     "itemsSkipped": "Pyetjet që keni tejkaluar:"
+  },
+  "de-DE": {
+    "greeting": "Hallo Benutzer",
+    "gameTitle": "Du spielst das Spiel \"Word Whisper!\"",
+    "chooseCategory": "Bitte wähle eine Kategorie, indem du in das Mikrofon sprichst",
+    "tip": "Tipp: Klicke auf den Talk-Button und sage den Kategorienamen",
+    "skipHint": "Tipp: Während des Spiels kannst du 'überspringen' sagen",
+    "whisperPrompt": "Sag uns, was das ist?",
+    "playAgain": "Sage 'Nochmal spielen' um neu zu starten",
+    "categoryComplete": "Hurra! Du hast die Kategorie abgeschlossen!",
+    "yourScore": "Dein Ergebnis ist:",
+    "skip": "überspringen",
+    "progressOf": "von",
+    "progressItems": "Fragen",
+    "playSound": "Ton abspielen",
+    "pauseSound": "Ton pausieren",
+    "itemsSkipped": "Übersprungene Fragen:"
   }
 }


### PR DESCRIPTION
feat: Add German language support

- Add German translations to langPhrases.json
- Add German translations to gameCategories.json
- Add German pronunciations to gameData.json
- Add German flag SVG
- Update language selector to include German option
- Update setLanguage function to handle German language
- Add German translations for cartoon names
- Add German translations for game instructions
- Add German translations for UI elements
- Add German translations for progress indicators

This commit adds full German language support to the game,
including translations, pronunciations, and UI elements.
The game now supports three languages: English, Albanian, and German.